### PR TITLE
Support building podman-machine-os from this workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ skopeo copy --authfile /path/to/pull-secret docker://registry.com/org/repo:lates
 You can now take that ociarchive and create a disk image for a
 platform (i.e. `qemu`, `metal` or `gcp`). First you need an
 environment to run OSBuild in. Right now this needs to be a
-fully up to date Fedora 40 machine with SELinux in permissive
+fully up to date Fedora 41 machine with SELinux in permissive
 mode and some software installed:
 
 ```
 sudo dnf update -y
 sudo setenforce 0
 sudo sed -i -e 's/SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config
-sudo dnf install -y --enablerepo=updates-testing osbuild osbuild-tools osbuild-ostree podman jq xfsprogs e2fsprogs
+sudo dnf install -y osbuild osbuild-tools osbuild-ostree podman jq xfsprogs e2fsprogs
 ```
 
 Now you should be able to generate an image with something like:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Now you should be able to generate an image with something like:
 ```
 ociarchive=/path/to/my-custom-rhcos.ociarchive
 platform=qemu
-sudo ./custom-coreos-disk-images.sh $ociarchive $platform
+sudo ./custom-coreos-disk-images.sh --ociarchive $ociarchive --platforms $platform
 ```
 
 Which will create the file `my-custom-rhcos.ociarchive.x86_64.qcow2` in

--- a/custom-coreos-disk-images.sh
+++ b/custom-coreos-disk-images.sh
@@ -133,11 +133,17 @@ main() {
 
         suffix=
         case $platform in 
-            metal)
+            applehv)
                 suffix=raw
                 ;;
             gcp)
                 suffix=tar.gz
+                ;;
+            hyperv)
+                suffix=vhdx
+                ;;
+            metal)
+                suffix=raw
                 ;;
             qemu)
                 suffix=qcow2

--- a/custom-coreos-disk-images.sh
+++ b/custom-coreos-disk-images.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/bash
 set -x -euo pipefail
 
-# Run this script on a fully up to date Fedora 40 VM with SELinux
+# Run this script on a fully up to date Fedora 41 VM with SELinux
 # in permissive mode and the following tools installed:
-# sudo dnf install -y --enablerepo=updates-testing osbuild osbuild-tools osbuild-ostree podman jq xfsprogs e2fsprogs
+# sudo dnf install -y osbuild osbuild-tools osbuild-ostree podman jq xfsprogs e2fsprogs
 #
 # Invocation of the script would look something like this:
 #

--- a/custom-coreos-disk-images.sh
+++ b/custom-coreos-disk-images.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
-set -x -euo pipefail
+set -eux -o pipefail
 
 # Run this script on a fully up to date Fedora 41 VM with SELinux
 # in permissive mode and the following tools installed:
@@ -94,7 +94,7 @@ main() {
         esac
         outfile="./$(basename $OCIARCHIVE).${ARCH}.${platform}.${suffix}"
 
-        # - rootfs size is only used on s390x secex so we pass "" here
+        # - rootfs size is only used on s390x secex so we pass "0" here
         # - extra-kargs from image.yaml/image.json is currently empty
         #   on RHCOS but we may want to start picking it up from inside
         #   the container image (/usr/share/coreos-assembler/image.json)


### PR DESCRIPTION
Found out the podman folks were still using https://github.com/dustymabe/build-podman-machine-os-disks which was really meant to be a temporary thing. Let's just update this repo for that use case and share the code.

See individual commit messages.