### PR TITLE
fix script syntax

### DIFF
--- a/custom-coreos-disk-images.sh
+++ b/custom-coreos-disk-images.sh
@@ -79,7 +79,7 @@ main() {
         --osname)
             shift # The arg is next in position args
             osname=$1
-            if [ $osname !~ rhcos|fedora-coreos ]; then
+            if [ "$osname" != rhcos ] && [ "$osname" != fedora-coreos ]; then
                 echo "--osname must be rhcos or fedora-coreos" >&2
                 exit 1
             fi


### PR DESCRIPTION
[ $osname !~ rhcos|fedora-coreos ]
is not valid shell, !~ will resolve to the last entry in the shell history using "~". There is no match for saying NOT regex.

Failure from the logs:
custom-coreos-disk-images.sh: line 82: [: missing `]' custom-coreos-disk-images.sh: line 82: fedora-coreos: command not found

Given we just have two values use two normal != conditions to match.