### PR TITLE
support building live artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ mode and some software installed:
 sudo dnf update -y
 sudo setenforce 0
 sudo sed -i -e 's/SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config
-sudo dnf install -y osbuild osbuild-tools osbuild-ostree podman jq xfsprogs e2fsprogs
+sudo dnf install -y osbuild osbuild-tools osbuild-ostree podman jq \
+    xfsprogs e2fsprogs dosfstools genisoimage squashfs-tools syslinux-nonlinux
 ```
 
 Now you should be able to generate an image with something like:
@@ -91,6 +92,21 @@ sudo ./custom-coreos-disk-images.sh --ociarchive $ociarchive --platforms $platfo
 
 Which will create the file `my-custom-rhcos.ociarchive.x86_64.qcow2` in
 the current working directory that can then be used.
+
+Another example, this time generating live artifacts (ISO/PXE):
+
+```
+ociarchive=/path/to/my-custom-rhcos.ociarchive
+platform=live
+sudo ./custom-coreos-disk-images.sh --ociarchive $ociarchive --platforms $platform
+```
+
+Will create the following files:
+
+- `my-custom-rhcos-live-initramfs.x86_64.img`
+- `my-custom-rhcos-live-iso.x86_64.iso`
+- `my-custom-rhcos-live-kernel.x86_64`
+- `my-custom-rhcos-live-rootfs.x86_64.img`
 
 # Using the container image in the cluster
 

--- a/custom-coreos-disk-images.sh
+++ b/custom-coreos-disk-images.sh
@@ -141,7 +141,7 @@ main() {
     fi
 
     # Default Metal Image Size
-    metal_image_size="${metal_image_size:-3072}"
+    metal_image_size="${metal_image_size:-4096}"
 
     # Default kernel arguments are different for FCOS/RHCOS
     if [ -z "${extra_kargs:-}" ]; then


### PR DESCRIPTION
This includes support for generating live ISO/PXE artifacts from the derived container image, which can be required for initial installs.

This leverages a new stage of osbuild that was recently released upstream with https://github.com/osbuild/osbuild/pull/1947 included.