### PR TITLE
fix: allow script to run when SELinux is disabled

### DIFF
--- a/custom-coreos-disk-images.sh
+++ b/custom-coreos-disk-images.sh
@@ -139,9 +139,9 @@ main() {
 
     # Make sure RPMs are installed
     check_rpms
-    # Make sure SELinux is permissive
-    if [ "$(getenforce)" != "Permissive" ]; then
-        echo "SELinux needs to be set to permissive mode"
+    # Make sure SELinux is not enforcing
+    if [ "$(getenforce)" == "Enforcing" ]; then
+        echo "SELinux needs to be set to either permissive or disabled"
         exit 1
     fi
     # Make sure we are effectively `root`


### PR DESCRIPTION
When running this script inside a container, restricting the SELinux check to permissive mode is limiting. Allowing the script to also run when SELinux is disabled improves usability, especially in containerized environments where SELinux enforcement is often turned off.